### PR TITLE
The excel formatter can prevent files from being read again if it is …

### DIFF
--- a/jkind-common/src/jkind/excel/ExcelFormatter.java
+++ b/jkind-common/src/jkind/excel/ExcelFormatter.java
@@ -64,14 +64,24 @@ public class ExcelFormatter implements Closeable {
 
 	@Override
 	public void close() {
+		String str = "";
 		try {
 			if (workbook != null) {
 				workbook.write();
-				workbook.close();
-				workbook = null;
 			}
 		} catch (Exception e) {
-			throw new JKindException("Error closing Excel file", e);
+			str += "Error writing to Excel file\n";
+		}
+		try{
+			if(workbook != null){
+				workbook.close();
+			}
+		} catch (Exception e){
+			str += "Error closing Excel file";
+		}
+		workbook = null;
+		if(!str.equals("")){
+			throw new JKindException(str);
 		}
 	}
 


### PR DESCRIPTION
…not closed properly. If the call to 'write' fails then the file may not close properly