### PR TITLE
API update for JVM arguments

### DIFF
--- a/jkind-api/src/jkind/api/JKindApi.java
+++ b/jkind-api/src/jkind/api/JKindApi.java
@@ -233,8 +233,7 @@ public class JKindApi extends KindApi {
 		args.add(getOrFindJKindJar());
 		args.add("-jkind");
 		
-		String[] rv = args.toArray(new String[args.size()]);
-		return rv;
+		return args.toArray(new String[args.size()]);
 	}
 
 	private String getOrFindJKindJar() {

--- a/jkind-api/src/jkind/api/JKindApi.java
+++ b/jkind-api/src/jkind/api/JKindApi.java
@@ -3,6 +3,7 @@ package jkind.api;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +29,7 @@ public class JKindApi extends KindApi {
 	protected boolean smoothCounterexamples = false;
 	protected boolean slicing = true;
 	
-	protected List<String> vmArgs = new ArrayList<>();
+	protected List<String> vmArgs = Collections.emptyList();
 
 	protected SolverOption solver = null;
 
@@ -232,8 +233,7 @@ public class JKindApi extends KindApi {
 		args.add(getOrFindJKindJar());
 		args.add("-jkind");
 		
-		String[] rv = new String[args.size()];
-		rv = args.toArray(rv);
+		String[] rv = args.toArray(new String[args.size()]);
 		return rv;
 	}
 

--- a/jkind-api/src/jkind/api/JKindApi.java
+++ b/jkind-api/src/jkind/api/JKindApi.java
@@ -27,6 +27,8 @@ public class JKindApi extends KindApi {
 	protected boolean ivcReduction = false;
 	protected boolean smoothCounterexamples = false;
 	protected boolean slicing = true;
+	
+	protected List<String> vmArgs = new ArrayList<>();
 
 	protected SolverOption solver = null;
 
@@ -106,6 +108,13 @@ public class JKindApi extends KindApi {
 	 */
 	public void disableSlicing() {
 		slicing = false;
+	}
+	
+	/**
+	 * Set VM args
+	 */
+	public void setVmArgs(List<String> args) {
+		vmArgs = new ArrayList<>(args);
 	}
 
 	/**
@@ -216,7 +225,16 @@ public class JKindApi extends KindApi {
 	}
 
 	protected String[] getJKindCommand() {
-		return new String[] { ApiUtil.getJavaPath(), "-jar", getOrFindJKindJar(), "-jkind" };
+		List<String> args = new ArrayList<>();
+		args.add(ApiUtil.getJavaPath());
+		args.addAll(vmArgs);
+		args.add("-jar");
+		args.add(getOrFindJKindJar());
+		args.add("-jkind");
+		
+		String[] rv = new String[args.size()];
+		rv = args.toArray(rv);
+		return rv;
 	}
 
 	private String getOrFindJKindJar() {

--- a/jkind-api/src/jkind/api/JRealizabilityApi.java
+++ b/jkind-api/src/jkind/api/JRealizabilityApi.java
@@ -3,6 +3,7 @@ package jkind.api;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,7 @@ public class JRealizabilityApi {
 	private boolean reduce = false;
 	private DebugLogger debug = new DebugLogger();
 	
-	private List<String> vmArgs = new ArrayList<>();
+	private List<String> vmArgs = Collections.emptyList();
 
 	private String jkindJar;
 	private Map<String, String> environment = new HashMap<>();
@@ -197,8 +198,7 @@ public class JRealizabilityApi {
 		args.add(getOrFindJKindJar());
 		args.add("-jrealizability");
 		
-		String[] rv = new String[args.size()];
-		rv = args.toArray(rv);
+		String[] rv = args.toArray(new String[args.size()]);
 		return rv;
 	}
 

--- a/jkind-api/src/jkind/api/JRealizabilityApi.java
+++ b/jkind-api/src/jkind/api/JRealizabilityApi.java
@@ -198,8 +198,7 @@ public class JRealizabilityApi {
 		args.add(getOrFindJKindJar());
 		args.add("-jrealizability");
 		
-		String[] rv = args.toArray(new String[args.size()]);
-		return rv;
+		return args.toArray(new String[args.size()]);
 	}
 
 	private String getOrFindJKindJar() {

--- a/jkind-api/src/jkind/api/JRealizabilityApi.java
+++ b/jkind-api/src/jkind/api/JRealizabilityApi.java
@@ -22,6 +22,8 @@ public class JRealizabilityApi {
 	private boolean extendCounterexample = false;
 	private boolean reduce = false;
 	private DebugLogger debug = new DebugLogger();
+	
+	private List<String> vmArgs = new ArrayList<>();
 
 	private String jkindJar;
 	private Map<String, String> environment = new HashMap<>();
@@ -101,6 +103,13 @@ public class JRealizabilityApi {
 	public void setEnvironment(String key, String value) {
 		environment.put(key, value);
 	}
+	
+	/**
+	 * Set VM args
+	 */
+	public void setVmArgs(List<String> args) {
+		vmArgs = new ArrayList<>(args);
+	}	
 
 	/**
 	 * Run JRealizability on a Lustre program
@@ -180,8 +189,17 @@ public class JRealizabilityApi {
 		return builder;
 	}
 
-	private String[] getJRealizabilityCommand() {
-		return new String[] { ApiUtil.getJavaPath(), "-jar", getOrFindJKindJar(), "-jrealizability" };
+	protected String[] getJRealizabilityCommand() {
+		List<String> args = new ArrayList<>();
+		args.add(ApiUtil.getJavaPath());
+		args.addAll(vmArgs);
+		args.add("-jar");
+		args.add(getOrFindJKindJar());
+		args.add("-jrealizability");
+		
+		String[] rv = new String[args.size()];
+		rv = args.toArray(rv);
+		return rv;
 	}
 
 	private String getOrFindJKindJar() {


### PR DESCRIPTION
I updated the API to allow embedded JKind calls to pass JVM args for stack size, heapsize, etc. It's just a string list interface that gets embedded into the JAR call.